### PR TITLE
Adding TPS limit for incoming sessions

### DIFF
--- a/api/src/main/java/com/mobius/software/telco/protocols/diameter/DiameterStack.java
+++ b/api/src/main/java/com/mobius/software/telco/protocols/diameter/DiameterStack.java
@@ -146,4 +146,6 @@ public interface DiameterStack
     DiameterParser getGlobalParser();
     
     Boolean isSessionLess();
+
+	Boolean isNewIncomingSessionAllowed();
 }

--- a/impl/src/main/java/com/mobius/software/telco/protocols/diameter/impl/DiameterProviderImpl.java
+++ b/impl/src/main/java/com/mobius/software/telco/protocols/diameter/impl/DiameterProviderImpl.java
@@ -173,12 +173,18 @@ public abstract class DiameterProviderImpl<L1 extends SessionListener, L2 extend
 			return;
 		}
 		
+		if (!stack.isNewIncomingSessionAllowed()) {
+			callback.onError(new DiameterException("The number of created incoming sessions exceeed the license limit", null, ResultCodes.DIAMETER_TOO_BUSY, null));
+			return;
+		}
+
 		DiameterSession session = this.getStack().getSessionStorage().getSession(sessionID, this);
 		if(session==null && (message instanceof DiameterRequest))
 		{
 			if(logger.isDebugEnabled())
 				logger.debug(String.format("Getting new session for message %s in provider %s", message.getClass().getCanonicalName(), getClass().getCanonicalName()));
 			
+
 			session=getNewSession((DiameterRequest)message);
 			if(session!=null)
 			{
@@ -203,18 +209,10 @@ public abstract class DiameterProviderImpl<L1 extends SessionListener, L2 extend
 				}
 				
 				getStack().getSessionStorage().storeSession(session);
-			}
-			else
-			{
-				if(logger.isDebugEnabled())
-					logger.debug(String.format("New session is null in provider %s", message.getClass().getCanonicalName(), getClass().getCanonicalName()));
-			}
-		}
-		else
-		{
-			if(logger.isDebugEnabled())
-				logger.debug(String.format("Processing message %s in existing session in provider %s", message.getClass().getCanonicalName(), getClass().getCanonicalName()));
-		}	
+			} else if(logger.isDebugEnabled())
+				logger.debug(String.format("New session is null in provider %s", message.getClass().getCanonicalName(), getClass().getCanonicalName()));
+		} else if(logger.isDebugEnabled())
+			logger.debug(String.format("Processing message %s in existing session in provider %s", message.getClass().getCanonicalName(), getClass().getCanonicalName()));	
 			
 		if(session==null)
 		{

--- a/impl/src/main/java/com/mobius/software/telco/protocols/diameter/impl/DiameterStackImpl.java
+++ b/impl/src/main/java/com/mobius/software/telco/protocols/diameter/impl/DiameterStackImpl.java
@@ -273,6 +273,7 @@ public class DiameterStackImpl implements DiameterStack
 		registeredProvidersByClass.putIfAbsent(provider.getClass(), provider);
 	}
 	
+	@Override
 	public DiameterProvider<?,?,?,?,?> getProvider(Class<?> providerClass)
 	{
 		return registeredProvidersByClass.get(providerClass);
@@ -1525,11 +1526,13 @@ public class DiameterStackImpl implements DiameterStack
 		return this.classLoader;
 	}
 	
+	@Override
 	public void registerGlobalApplication(Package providerPackageName, Package packageName) throws DiameterException
 	{
 		globalParser.registerGlobalApplication(classLoader, providerPackageName, packageName);
 	}
 	
+	@Override
 	public DiameterParser getGlobalParser()
 	{
 		return globalParser;
@@ -1545,5 +1548,10 @@ public class DiameterStackImpl implements DiameterStack
 	public ClusteredID<?> generateID()
 	{
 		return idGenerator.generateID();
+	}
+
+	@Override
+	public Boolean isNewIncomingSessionAllowed() {
+		return true;
 	}
 }


### PR DESCRIPTION
- Adding _isNewSessionAllowed_ method to **DiameterStack** interface;
- Adding implementation of _isNewSessionAllowed_ in **DiameterStackImpl**;
- Updating **DiameterProviderImpl** to check if can new session be created, otherwise return _DIAMETER_TOO_BUSY_ error code.